### PR TITLE
Previous bed settings & reverse stepper setting

### DIFF
--- a/Configuration.h
+++ b/Configuration.h
@@ -124,7 +124,7 @@
 
 // Optional custom name for your RepStrap or other custom machine
 // Displayed in the LCD "Ready" message
-#define CUSTOM_MACHINE_NAME "N3J 3D Printer" // Enabled this and gave it a name
+#define CUSTOM_MACHINE_NAME "N3J 3D 2.0" // Enabled this and gave it a name
 
 // Define this to set a unique identifier for this printer, (Used by some programs to differentiate between machines)
 // You can use an online service to generate a random UUID. (eg http://www.uuidgenerator.net/version4)
@@ -683,8 +683,8 @@
  *      O-- FRONT --+
  *    (0,0)
  */
-#define X_PROBE_OFFSET_FROM_EXTRUDER -29  // X offset: -left  +right  [of the nozzle]- JJ_PROBE -> Adapted to measured offset
-#define Y_PROBE_OFFSET_FROM_EXTRUDER -48  // Y offset: -front +behind [the nozzle] - JJ_PROBE -> Adapted to measured offset
+#define X_PROBE_OFFSET_FROM_EXTRUDER -34  // X offset: -left  +right  [of the nozzle]- JJ_PROBE -> adapted to measured offset
+#define Y_PROBE_OFFSET_FROM_EXTRUDER -45  // Y offset: -front +behind [the nozzle] - JJ_PROBE -> Adapted to measured offset
 #define Z_PROBE_OFFSET_FROM_EXTRUDER 0   // Z offset: -below +above  [the nozzle] - JJ_PROBE -> Set during tuning from LCD
 
 // X and Y axis travel speed (mm/m) between probes
@@ -758,7 +758,7 @@
 // @section extruder
 
 // For direct drive extruder v9 set to true, for geared extruder set to false.
-#define INVERT_E0_DIR true // 31/05/2018 Changed back to true after installation of original mechanism. Still bowden style
+#define INVERT_E0_DIR true // 01/05/2018 changed again after changinf stepper setup
 #define INVERT_E1_DIR false
 #define INVERT_E2_DIR false
 #define INVERT_E3_DIR false
@@ -780,8 +780,8 @@
 // @section machine
 
 // The size of the print bed
-#define X_BED_SIZE 220 // 29/05 - Set to actual size based on measurements with ruler
-#define Y_BED_SIZE 220 // 29/05 - Set to actual size based on measurements with ruler
+#define X_BED_SIZE 200 // 22/04/2018 Change back to default from 205
+#define Y_BED_SIZE 200 // 22/04/2018 Change back to default from 205
 
 // Travel limits (mm) after homing, corresponding to endstop positions.
 #define X_MIN_POS 0
@@ -1031,7 +1031,7 @@
 // - Move the Z probe (or nozzle) to a defined XY point before Z Homing when homing all axes (G28).
 // - Prevent Z homing when the Z probe is outside bed area.
 //
-#define Z_SAFE_HOMING // JJ_PROBE - Z MIN stays end stop for homing (put back on as swaping pins)
+#define Z_SAFE_HOMING // JJ_PROBE - keeping option disabled since probe is installed on the Z MAX, Z MIN stays end stop for homing (put back on as swaping pins)
 
 #if ENABLED(Z_SAFE_HOMING)
   #define Z_SAFE_HOMING_X_POINT ((X_BED_SIZE) / 2)    // X point for Z homing when homing all axes (G28).


### PR DESCRIPTION
Issues with printing.
To exclude any issue that may have come from recent changes to bed size, went back to previous version
(ie: reset z probe offsets and bed size) -> this can be put back later
Also changed extruder mount that required reversing stepper direction
Finally added versioning to which is displayed on the LCD